### PR TITLE
修正在Chrome下单击左侧API时控制台报错的问题

### DIFF
--- a/api/index.html
+++ b/api/index.html
@@ -459,7 +459,7 @@ $("a[name='apiSwitch']").powerSwitch({
 	classAdd: "zxx_api_on",
 	animation: "visibility",
 	onSwitch: function(target) {
-		location.replace(this.href);
+		location.hash = this.getAttribute('href', 2);
 		// IE6 宽度
 		if (!window.XMLHttpRequest) {
 			target.css("width", $(window).width() - 254);	


### PR DESCRIPTION
错误信息:
`Uncaught RangeError: Maximum call stack size exceeded.`
原因是:
使用location.replace会导致页面重新加载,当有hash值时,`powerSwitch`会自动触发click事件(576行),而`click`事件会触发`onSwitch`事件,所以就死循环了.

```
if (anchorSplit && element.href && anchorSplit == element.href.split("#")[1]) {
    $(element).trigger("click");    
}
```
